### PR TITLE
Fix name spacing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CSCI3251_YisuLI
-This is the project of YisuLI.
-Hello, I'm YisuLI!
+This is the project of Yisu Li.
+Hello, I'm Yisu Li!
 My student number is 1155210982!
+


### PR DESCRIPTION
## Summary
- fix incorrect spacing for the author's name
- add trailing newline to README for proper formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68922609685083208dc08bfa8c820046